### PR TITLE
Fix/9 error handling unit tests

### DIFF
--- a/EnvironmentManager.Test/AllMaintenanceViewModelTests.cs
+++ b/EnvironmentManager.Test/AllMaintenanceViewModelTests.cs
@@ -1,6 +1,8 @@
 namespace EnvironmentManager.Test;
 
 using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Text;
 using EnvironmentManager.Data;
 using EnvironmentManager.Models;
 using EnvironmentManager.ViewModels;
@@ -12,6 +14,66 @@ public class AllMaintenanceViewModelTests
     public void SortCollection_OnInstantiation_SortList()
     {
         //Arrange
+        var contextMock = createContext();
+        //Action
+        AllMaintenanceViewModel allMaintenance = new AllMaintenanceViewModel(contextMock.Object); //SortCollection function invoked as part of constructor
+        ObservableCollection<MaintenanceViewModel> producedCollection = allMaintenance.AllMaintenance; //Get sorted collection
+        //Assert
+        for(var i = 1; i < producedCollection.Count; i++){
+            Assert.True(producedCollection[i].Priority >= producedCollection [i-1].Priority); //verify order, sorted in ascending
+        }
+    }
+
+    [Fact]
+    public void HandleError_Store()
+    {
+        // Arrange
+        var contextMock = createContext();
+        AllMaintenanceViewModel allMaintenance = new AllMaintenanceViewModel(contextMock.Object);
+        
+        // Action
+        string exceptionMessage = "test exception";
+        string errorMessage = "test message";
+        try
+        {
+            throw new Exception(exceptionMessage);
+        }
+        catch(Exception e)
+        {
+            allMaintenance.HandleError(e, errorMessage);
+        }
+        //Assert
+        Assert.Equal(allMaintenance.DisplayError, errorMessage);
+    }
+
+    [Fact]
+    public void HandleError_Trace()
+    {
+        // Arrange
+        var contextMock = createContext();
+        AllMaintenanceViewModel allMaintenance = new AllMaintenanceViewModel(contextMock.Object);
+        StringBuilder builder = new StringBuilder();
+        StringWriter writer = new StringWriter(builder);
+        TextWriterTraceListener listener = new TextWriterTraceListener(writer);
+        Trace.Listeners.Add(listener);
+        
+        // Action
+        string exceptionMessage = "test exception";
+        string errorMessage = "test message";
+        try
+        {
+            throw new Exception(exceptionMessage);
+        }
+        catch(Exception e)
+        {
+            allMaintenance.HandleError(e, errorMessage);
+        }
+        //Assert
+        string traceContents = builder.ToString().Replace("\n","");
+        Assert.Equal(exceptionMessage, traceContents);
+    }
+
+    private Mock<MaintenanceDbContext> createContext() {
         var contextMock = new Mock<MaintenanceDbContext>();
         Random rand = new Random();
         List<Maintenance> testList = new List<Maintenance>();
@@ -26,12 +88,6 @@ public class AllMaintenanceViewModelTests
         }
         var dbSet = TestUtils.MockDbSet(testList);
         contextMock.Setup(c => c.Maintenance).Returns(dbSet.Object);
-        //Action
-        AllMaintenanceViewModel allMaintenance = new AllMaintenanceViewModel(contextMock.Object); //SortCollection function invoked as part of constructor
-        ObservableCollection<MaintenanceViewModel> producedCollection = allMaintenance.AllMaintenance; //Get sorted collection
-        //Assert
-        for(var i = 1; i < producedCollection.Count; i++){
-            Assert.True(producedCollection[i].Priority >= producedCollection [i-1].Priority); //verify order, sorted in ascending
-        }
+        return contextMock;
     }
 }

--- a/EnvironmentManager.Test/MaintenanceViewModelTests.cs
+++ b/EnvironmentManager.Test/MaintenanceViewModelTests.cs
@@ -1,5 +1,7 @@
 namespace EnvironmentManager.Test;
 
+using System.Diagnostics;
+using System.Text;
 using EnvironmentManager.Data;
 using EnvironmentManager.Models;
 using EnvironmentManager.ViewModels;
@@ -49,5 +51,54 @@ public class MaintenanceViewModelTests
         //Assert
         contextMock.Verify(mock => mock.SaveChanges(), Times.Once());
         Assert.False(maintenance.Overdue);
+    }
+
+    [Fact]
+    public void HandleError_Store()
+    {
+        // Arrange
+        var contextMock = new Mock<MaintenanceDbContext>();
+        MaintenanceViewModel maintenance = new MaintenanceViewModel(contextMock.Object);
+        
+        // Action
+        string exceptionMessage = "test exception";
+        string errorMessage = "test message";
+        try
+        {
+            throw new Exception(exceptionMessage);
+        }
+        catch(Exception e)
+        {
+            maintenance.HandleError(e, errorMessage);
+        }
+        //Assert
+        Assert.Equal(maintenance.DisplayError, errorMessage);
+    }
+
+    [Fact]
+    public void HandleError_Trace()
+    {
+        // Arrange
+        var contextMock = new Mock<MaintenanceDbContext>();
+        MaintenanceViewModel maintenance = new MaintenanceViewModel(contextMock.Object);
+        StringBuilder builder = new StringBuilder();
+        StringWriter writer = new StringWriter(builder);
+        TextWriterTraceListener listener = new TextWriterTraceListener(writer);
+        Trace.Listeners.Add(listener);
+        
+        // Action
+        string exceptionMessage = "test exception";
+        string errorMessage = "test message";
+        try
+        {
+            throw new Exception(exceptionMessage);
+        }
+        catch(Exception e)
+        {
+            maintenance.HandleError(e, errorMessage);
+        }
+        //Assert
+        string traceContents = builder.ToString().Replace("\n","");
+        Assert.Equal(exceptionMessage, traceContents);
     }
 }


### PR DESCRIPTION
Added missing UnitTests for HandleError public method.

Extracted creation of mocked db context with ObservableCollection to a private method, as it is required to instantiate an instance of AllMaintenanceViewModel.